### PR TITLE
normalize observation

### DIFF
--- a/gymnasium_env/arm.py
+++ b/gymnasium_env/arm.py
@@ -4,6 +4,7 @@ import mujoco
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
 from dataclasses import dataclass
+import copy
 
 DEFAULT_CAMERA_CONFIG = {
     "trackbodyid": 0,
@@ -56,9 +57,9 @@ class ArmEnv(MujocoEnv):
         if not path.exists(xml_file):
             raise FileNotFoundError(f"Mujoco model not found: {xml_file}")
             
-        observation_space = Box(low=-np.inf, high=np.inf, shape=(15,), dtype=np.float64)
+        observation_space = Box(low=-1, high=1, shape=(15,), dtype=np.float64)
 
-        self.goal = np.array([0.5,0.1,0.1])
+        self._sample_goal()
 
         self.load_data = self.LoadData(xml_file=xml_file,
                                        frame_skip=frame_skip,
@@ -106,7 +107,7 @@ class ArmEnv(MujocoEnv):
         # as possible so that the maximum reward is obtained for each step of
         # the environment.
         ee_pos = self.data.site("gripper").xpos
-        dist = np.linalg.norm(ee_pos - self.goal)
+        dist = np.linalg.norm(ee_pos - self.goal_to_xyz())
         assert(dist > 0)
 
         reward = np.exp(-10*dist)
@@ -141,16 +142,22 @@ class ArmEnv(MujocoEnv):
             high = np.array([0.4064,0,0.25]), # upper bound
         )
 
+        self.goal_rpz = np.array([rho, phi, z])
+
+
+    def goal_to_xyz(self):
+        rho, phi, z = self.goal_rpz
         # transform cylindrical to cartesian coordinates
         x = rho*np.cos(phi)
         y = rho*np.sin(phi)
         return np.array([x,y,z])
 
+
     # override
     def reset_model(self):
         self.steps=0
         #Randomization of goal point
-        self.goal = self._sample_goal()
+        self._sample_goal()
         self._load_env()
         mujoco.mj_forward(self.model, self.data)
         
@@ -158,7 +165,22 @@ class ArmEnv(MujocoEnv):
 
     
     def _get_obs(self):
-        return np.concatenate([self.data.qpos, self.data.qvel, self.goal]).ravel() #edited to return goal
+        # normalize observation data
+        q_max = np.pi
+        q_norm = copy.deepcopy(self.data.qpos) / q_max
+        dq_max = np.pi
+        dq_norm = copy.deepcopy(self.data.qvel) / dq_max
+        goal_rpz_norm = copy.deepcopy(self.goal_rpz)
+        goal_rpz_norm[0] = (goal_rpz_norm[0]-0.1143)/(0.4064-0.1143)
+        # remember y range is negative
+        goal_rpz_norm[1] = -goal_rpz_norm[1]/np.pi
+        goal_rpz_norm[2] = (goal_rpz_norm[2]-0.075)/(0.25-0.075)
+        # each normalized goal element is now within [0,1], but the other
+        # observations are within [-1,1] so adjust the goal elements to be
+        # within [-1,1]
+        goal_rpz_norm = goal_rpz_norm*2-1
+        obs = np.concatenate([q_norm, dq_norm, goal_rpz_norm]).ravel() #edited to return goal
+        return obs
     
 
     def _initialize_simulation(self) -> tuple["mujoco.MjModel", "mujoco.MjData"]:
@@ -170,7 +192,7 @@ class ArmEnv(MujocoEnv):
 
         # add sites whose frames will be displayed by default
 
-        # readd the gripper site (not sure why the already existing site is not
+        # re-add the gripper site (not sure why the already existing site is not
         # displayed)
         gripper_body = spec.body("gripper")
         gripper_site = spec.site("gripper")
@@ -179,7 +201,7 @@ class ArmEnv(MujocoEnv):
         
         # add a site for the goal
         spec.worldbody.add_site(
-            pos=self.goal,
+            pos=self.goal_to_xyz(),
             quat=[0, 1, 0, 0],
         )
         


### PR DESCRIPTION
Normalizing the observation makes the weighting of each feature equal and results in faster gradient descent convergence. This small change reduces training time and increases the return per episode. The robot now moves to the goal quickly and accurately with consistency.